### PR TITLE
Update compact_str to v0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ sha-1 = "0.10.0"
 hmac = "0.12.0"
 lazy_static = "1.4.0"
 ignore-result = "0.2.0"
-compact_str = "0.2.0"
+compact_str = "0.4"
 etcd-client = "0.8.2"
 async-recursion = "1.0.0"
 strum = { version = "0.23", features = ["derive"] }

--- a/src/client/metadata.rs
+++ b/src/client/metadata.rs
@@ -341,7 +341,7 @@ pub(crate) trait HasLedgerMetadata {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct BookieId(compact_str::CompactStr);
+pub struct BookieId(compact_str::CompactString);
 
 impl BookieId {
     pub fn new(s: &str) -> BookieId {

--- a/src/client/service_uri.rs
+++ b/src/client/service_uri.rs
@@ -1,14 +1,14 @@
 use std::str::FromStr;
 
-use compact_str::CompactStr;
+use compact_str::CompactString;
 
 use super::errors::{BkError, ErrorKind};
 
 pub struct ServiceUri {
-    pub scheme: CompactStr,
-    pub spec: CompactStr,
-    pub address: CompactStr,
-    pub path: CompactStr,
+    pub scheme: CompactString,
+    pub spec: CompactString,
+    pub address: CompactString,
+    pub path: CompactString,
 }
 
 impl FromStr for ServiceUri {

--- a/src/meta/etcd.rs
+++ b/src/meta/etcd.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use either::Either;
 use etcd_client::{
     Client,
@@ -118,7 +118,7 @@ impl types::LedgerMetadataStream for LedgerMetadataStream {
 }
 
 pub struct EtcdConfiguration {
-    scope: CompactStr,
+    scope: CompactString,
     #[allow(dead_code)]
     user: Option<(String, String)>,
     #[allow(dead_code)]
@@ -126,7 +126,7 @@ pub struct EtcdConfiguration {
 }
 
 impl EtcdConfiguration {
-    pub fn new(scope: CompactStr) -> EtcdConfiguration {
+    pub fn new(scope: CompactString) -> EtcdConfiguration {
         EtcdConfiguration { scope, user: None, keep_alive: None }
     }
 
@@ -142,7 +142,7 @@ impl EtcdConfiguration {
 }
 
 pub struct EtcdMetaStore {
-    scope: CompactStr,
+    scope: CompactString,
     client: KvClient,
     watcher: WatchClient,
     bucket_counter: AtomicU64,

--- a/src/meta/types.rs
+++ b/src/meta/types.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use either::Either;
 use prost::Message;
 
@@ -104,10 +104,10 @@ impl BookieServiceInfo {
 
 #[derive(Clone)]
 pub struct BookieEndpoint {
-    pub id: CompactStr,
-    pub host: CompactStr,
+    pub id: CompactString,
+    pub host: CompactString,
     pub port: u16,
-    pub protocol: CompactStr,
+    pub protocol: CompactString,
 }
 
 impl From<bookie_service_info_format::Endpoint> for BookieEndpoint {

--- a/src/meta/zookeeper.rs
+++ b/src/meta/zookeeper.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
-use compact_str::CompactStr;
+use compact_str::CompactString;
 use either::Either;
 use guard::guard;
 use ignore_result::Ignore;
@@ -35,8 +35,8 @@ use crate::client::{BookieId, LedgerId, LedgerMetadata};
 #[derive(Clone)]
 pub struct ZkConfiguration {
     ledger_id_format: Option<LedgerIdFormat>,
-    root: CompactStr,
-    connect: CompactStr,
+    root: CompactString,
+    connect: CompactString,
     timeout: Duration,
 }
 
@@ -489,7 +489,7 @@ impl LedgerIdFormat {
 struct ZkMetaClient {
     client: Arc<ZkClient>,
     scratch: String,
-    ledger_root: CompactStr,
+    ledger_root: CompactString,
     ledger_id_format: LedgerIdFormat,
     ledger_hob: i32,
     ledger_path: String,


### PR DESCRIPTION
**Context**
In the most recent version of [`compact_str`](https://github.com/ParkMyCar/compact_str), we renamed `CompactStr` to `CompactString`. You can continue to use `CompactStr` but there is a deprecation warning on it.

**Changes**
This PR updates `compact_str` to `v0.4`, renaming uses of `CompactStr` to `CompactString` to prevent the warning